### PR TITLE
Fix hosts leak on freepool's destroy

### DIFF
--- a/rackattack/physical/dynamicconfig.py
+++ b/rackattack/physical/dynamicconfig.py
@@ -115,3 +115,6 @@ class DynamicConfig:
 
     def getOfflineHosts(self):
         return self._offlineHosts
+
+    def getOnlineHosts(self):
+        return self._onlineHosts


### PR DESCRIPTION
This makes destroyed hosts appear as destroyed, instead of not appearing at all , when fetching details about hosts' status.
See https://stratoscale.atlassian.net/browse/INF-531